### PR TITLE
add support for DELETE ... USING

### DIFF
--- a/delete.go
+++ b/delete.go
@@ -14,6 +14,7 @@ type deleteData struct {
 	RunWith           BaseRunner
 	Prefixes          []Sqlizer
 	From              string
+	Usings            []string
 	WhereParts        []Sqlizer
 	OrderBys          []string
 	Limit             string
@@ -47,6 +48,11 @@ func (d *deleteData) ToSql() (sqlStr string, args []interface{}, err error) {
 
 	sql.WriteString("DELETE FROM ")
 	sql.WriteString(d.From)
+
+	if len(d.Usings) > 0 {
+		sql.WriteString(" USING ")
+		sql.WriteString(strings.Join(d.Usings, ", "))
+	}
 
 	if len(d.WhereParts) > 0 {
 		sql.WriteString(" WHERE ")
@@ -144,6 +150,11 @@ func (b DeleteBuilder) PrefixExpr(expr Sqlizer) DeleteBuilder {
 // From sets the table to be deleted from.
 func (b DeleteBuilder) From(from string) DeleteBuilder {
 	return builder.Set(b, "From", from).(DeleteBuilder)
+}
+
+// Using adds USING expressions to the query.
+func (b DeleteBuilder) Using(usings ...string) DeleteBuilder {
+	return builder.Extend(b, "Usings", usings).(DeleteBuilder)
 }
 
 // Where adds WHERE expressions to the query.

--- a/delete_test.go
+++ b/delete_test.go
@@ -11,6 +11,7 @@ func TestDeleteBuilderToSql(t *testing.T) {
 		Prefix("WITH prefix AS ?", 0).
 		From("a").
 		Where("b = ?", 1).
+		Using("other").
 		OrderBy("c").
 		Limit(2).
 		Offset(3).
@@ -21,7 +22,7 @@ func TestDeleteBuilderToSql(t *testing.T) {
 
 	expectedSql :=
 		"WITH prefix AS ? " +
-			"DELETE FROM a WHERE b = ? ORDER BY c LIMIT 2 OFFSET 3 " +
+			"DELETE FROM a USING other WHERE b = ? ORDER BY c LIMIT 2 OFFSET 3 " +
 			"RETURNING ?"
 	assert.Equal(t, expectedSql, sql)
 


### PR DESCRIPTION
#### Summary
Postgres supports a `DELETE ... USING <table1>, <table2>, ...` syntax that simplifies joins when deleting rows. Support this extension in our fork of Squirrel to streamline building queries with same, e.g.:
```go
builder = s.getQueryBuilder().
	Delete("Drafts d").
	PrefixExpr(s.getQueryBuilder().Select().
		Prefix("WITH dd AS (").
		Columns("UserId", "ChannelId", "RootId").
		From("Drafts").
		Where(sq.Or{
			sq.Gt{"CreateAt": createAt},
			sq.And{
				sq.Eq{"CreateAt": createAt},
				sq.Gt{"UserId": userId},
			},
		}).
		OrderBy("CreateAt", "UserId").
		Limit(100).
		Suffix(")"),
	).
	Using("dd").
	Where("d.UserId = dd.UserId").
	Where("d.ChannelId = dd.ChannelId").
	Where("d.RootId = dd.RootId").
	Where("d.Message = ''")
```


#### Ticket Link
None.